### PR TITLE
Fix the fallthrough package name

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ case installation_method
 when "package"
   pkg_name = value_for_platform(
     "gentoo"  => { "default" => "sys-apps/ucspi-tcp" },
-    "default" => { "default" => "ucspi-tcp" }
+    "default" => "ucspi-tcp"
   )
 
   package pkg_name do


### PR DESCRIPTION
This should allow binary packages to work on Ubuntu, and other platforms
