### PR TITLE
Fix package installation on Chef 11

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,6 +40,8 @@ when "package"
     "gentoo"  => { "default" => "sys-apps/ucspi-tcp" },
     "default" => { "default" => "ucspi-tcp" }
   )
+  # Compatibility with Chef 11.
+  pkg_name = pkg_name["default"] if pkg_name.is_a?(Hash)
 
   package pkg_name do
     action :install


### PR DESCRIPTION
On Chef 11, `value_for_platform("default" => { "default" => "xxx" })` returns
`{ "default" => "xxx" }` instead of the expected "xxx". This breaks package
installation. This commit makes the cookbook work on both Chef 10 and Chef 11.
