### PR TITLE
fixing package hash problem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,12 @@ when "package"
   pkg_name = value_for_platform(
     "gentoo"  => "sys-apps/ucspi-tcp",
     "default" => "ucspi-tcp"
+  # "gentoo"  => { "default" => "sys-apps/ucspi-tcp" },
+  # "gentoo"  => { "default" => "sys-apps/ucspi-tcp" },
+  # "default" => { "default" => "ucspi-tcp" }
   )
+  # Foobar fix for chef 11
+  #pkg_name = pkg_name["default"] if pkg_name.is_a?(Hash)
 
   package pkg_name do
     action :install


### PR DESCRIPTION
package resource in chef expects the package names to be string or an array of strings.

So in the original cookbook we have 

```
"gentoo"  => { "default" => "sys-apps/ucspi-tcp" },
"default" => { "default" => "ucspi-tcp" }
```

for this i was getting below error.

[2014-03-04T11:15:21+00:00] ERROR: package[{"default"=>"ucspi-tcp"}](ucspi-tcp::default line 44) had an error: Chef::Exceptions::ValidationFailed: Option package_name must be a kind of [String]!  You passed {"default"=>"ucspi-tcp"}.
[2014-03-04T11:15:21+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)

I've added below changes
-    "gentoo"  => { "default" => "sys-apps/ucspi-tcp" },
-    "default" => { "default" => "ucspi-tcp" }
-    "gentoo"  => "sys-apps/ucspi-tcp",
-    "default" => "ucspi-tcp"

Its working fine for me . Let me know if there is another alternative for this . Will be happy to use that :)
