### PR TITLE
The default clause of value_for_platform shouldn't use a hash.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,14 +31,14 @@ installation_method = value_for_platform(
       "default" => "package"
     },
     "gentoo"  => { "default" => "package" },
-    "default" => { "default" => "source" }
+    "default" => "source"
 )
 
 case installation_method
 when "package"
   pkg_name = value_for_platform(
     "gentoo"  => { "default" => "sys-apps/ucspi-tcp" },
-    "default" => { "default" => "ucspi-tcp" }
+    "default" => "ucspi-tcp"
   )
 
   package pkg_name do


### PR DESCRIPTION
When you reach the "default" case of value for platform, it simply
returns the value, rather than trying to match on version.
